### PR TITLE
Refactor public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ public function routeNotificationForRocketChat(): string
 
 `alias()`:  This will cause the message’s name to appear as the given alias, but your username will still display.
 
-`emoji()`: This will make the avatar on this message be an emoji. (e.g. ":see_no_evil:")
+`emoji()`: This will make the avatar on this message be an emoji. (e.g. ':see_no_evil:')
 
 `avatar()`: This will make the avatar use the provided image url.
 
@@ -118,7 +118,7 @@ There are several ways to add one ore more attachments to a message
 ```php
 public function toRocketChat($notifiable)
 {
-    return RocketChatMessage::make("Test message")
+    return RocketChatMessage::make('Test message')
         ->to('channel_name') // optional if set in config
         ->from('webhook_token') // optional if set in config
         ->attachments([

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ class TaskCompleted extends Notification
 
     public function toRocketChat($notifiable): RocketChatMessage
     {
-        return RocketChatMessage::create('Test message')
+        return RocketChatMessage::make('Test message')
             ->to('channel_name') // optional if set in config
             ->from('webhook_token'); // optional if set in config
     }
@@ -118,12 +118,12 @@ There are several ways to add one ore more attachments to a message
 ```php
 public function toRocketChat($notifiable)
 {
-    return RocketChatMessage::create("Test message")
+    return RocketChatMessage::make("Test message")
         ->to('channel_name') // optional if set in config
         ->from('webhook_token') // optional if set in config
         ->attachments([
-            RocketChatAttachment::create()->imageUrl('test'),
-            RocketChatAttachment::create(['image_url' => 'test']),
+            RocketChatAttachment::make()->imageUrl('test'),
+            RocketChatAttachment::make(['image_url' => 'test']),
             new RocketChatAttachment(['image_url' => 'test']),
             [
                 'image_url' => 'test'

--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -17,7 +17,7 @@ final class CouldNotSendNotification extends RuntimeException
      */
     public static function missingTo(): self
     {
-        return new static('Notification was not sent. Channel identifier is missing.');
+        return new static('RocketChat notification was not sent. Channel identifier is missing.');
     }
 
     /**
@@ -27,7 +27,7 @@ final class CouldNotSendNotification extends RuntimeException
      */
     public static function missingFrom(): self
     {
-        return new static('Notification was not sent. Access token is missing.');
+        return new static('RocketChat notification was not sent. Access token is missing.');
     }
 
     /**

--- a/src/RocketChat.php
+++ b/src/RocketChat.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace NotificationChannels\RocketChat;
 
 use GuzzleHttp\Client as HttpClient;
-use Psr\Http\Message\ResponseInterface;
 
 final class RocketChat
 {
@@ -37,21 +36,11 @@ final class RocketChat
     }
 
     /**
-     * Returns RocketChat base url.
-     *
-     * @return string
-     */
-    public function url(): string
-    {
-        return $this->url;
-    }
-
-    /**
      * Returns RocketChat token.
      *
      * @return string
      */
-    public function token(): string
+    public function getToken(): string
     {
         return $this->token;
     }
@@ -61,7 +50,7 @@ final class RocketChat
      *
      * @return string|null
      */
-    public function defaultChannel(): ?string
+    public function getDefaultChannel(): ?string
     {
         return $this->defaultChannel;
     }
@@ -71,13 +60,13 @@ final class RocketChat
      *
      * @param  string  $to
      * @param  array  $message
-     * @return \Psr\Http\Message\ResponseInterface
+     * @return void
      */
-    public function sendMessage(string $to, array $message): ResponseInterface
+    public function sendMessage(string $to, array $message): void
     {
         $url = sprintf('%s/hooks/%s', $this->url, $this->token);
 
-        return $this->post($url, [
+        $this->post($url, [
             'json' => array_merge($message, [
                 'channel' => $to,
             ]),
@@ -89,10 +78,10 @@ final class RocketChat
      *
      * @param  string  $url
      * @param  array  $options
-     * @return \Psr\Http\Message\ResponseInterface
+     * @return void
      */
-    private function post(string $url, array $options): ResponseInterface
+    private function post(string $url, array $options): void
     {
-        return $this->http->post($url, $options);
+        $this->http->post($url, $options);
     }
 }

--- a/src/RocketChat.php
+++ b/src/RocketChat.php
@@ -37,16 +37,6 @@ final class RocketChat
     }
 
     /**
-     * Returns default channel id or name.
-     *
-     * @return string|null
-     */
-    public function channel(): ?string
-    {
-        return $this->defaultChannel;
-    }
-
-    /**
      * Returns RocketChat base url.
      *
      * @return string
@@ -64,6 +54,16 @@ final class RocketChat
     public function token(): string
     {
         return $this->token;
+    }
+
+    /**
+     * Returns default channel id or name.
+     *
+     * @return string|null
+     */
+    public function defaultChannel(): ?string
+    {
+        return $this->defaultChannel;
     }
 
     /**

--- a/src/RocketChatAttachment.php
+++ b/src/RocketChatAttachment.php
@@ -310,8 +310,9 @@ class RocketChatAttachment
      * Set attachment data from array.
      *
      * @param array $data
+     * @return void
      */
-    private function setPropertiesFromArray(array $data)
+    private function setPropertiesFromArray(array $data): void
     {
         foreach ($data as $key => $value) {
             $methodName = Str::camel($key);

--- a/src/RocketChatAttachment.php
+++ b/src/RocketChatAttachment.php
@@ -62,40 +62,22 @@ class RocketChatAttachment
     /**
      * RocketChatAttachment constructor.
      *
-     * @param array|null $config
+     * @param array $config
      */
-    public function __construct(array $config = null)
+    public function __construct(array $config = [])
     {
-        if ($config != null) {
-            $this->setFromArray($config);
-        }
+        $this->setFromArray($config);
     }
 
     /**
      * Create a new instance of RocketChatAttachment.
      *
-     * @param array|null $config
+     * @param array $config
      * @return RocketChatAttachment
      */
-    public static function create(array $config = null)
+    public static function make(array $config = [])
     {
         return new self($config);
-    }
-
-    /**
-     * Set attachment data form array.
-     *
-     * @param array $data
-     */
-    protected function setFromArray(array $data)
-    {
-        foreach ($data as $key => $value) {
-            $method = Str::camel($key);
-            if (! method_exists($this, $method)) {
-                continue;
-            }
-            $this->{$method}($value);
-        }
     }
 
     /**
@@ -322,5 +304,21 @@ class RocketChatAttachment
             'video_url' => $this->videoUrl,
             'fields' => $this->fields,
         ]);
+    }
+
+    /**
+     * Set attachment data form array.
+     *
+     * @param array $data
+     */
+    protected function setFromArray(array $data)
+    {
+        foreach ($data as $key => $value) {
+            $method = Str::camel($key);
+            if (! method_exists($this, $method)) {
+                continue;
+            }
+            $this->{$method}($value);
+        }
     }
 }

--- a/src/RocketChatAttachment.php
+++ b/src/RocketChatAttachment.php
@@ -11,50 +11,50 @@ use InvalidArgumentException;
 
 class RocketChatAttachment
 {
-    /** @var string The color you want the order on the left side to be, any value background-css supports. */
-    protected $color = '';
+    /** @var string|null The color you want the order on the left side to be, any value background-css supports. */
+    protected $color;
 
-    /** @var string The text to display for this attachment, it is different than the message’s text. */
-    protected $text = '';
+    /** @var string|null The text to display for this attachment, it is different than the message’s text. */
+    protected $text;
 
-    /** @var string Displays the time next to the text portion. */
-    protected $timestamp = '';
+    /** @var string|null Displays the time next to the text portion. */
+    protected $timestamp;
 
-    /** @var string An image that displays to the left of the text, looks better when this is relatively small. */
-    protected $thumbnailUrl = '';
+    /** @var string|null An image that displays to the left of the text, looks better when this is relatively small. */
+    protected $thumbnailUrl;
 
-    /** @var string Only applicable if the ts is provided, as it makes the time clickable to this link. */
-    protected $messageLink = '';
+    /** @var string|null Only applicable if the ts is provided, as it makes the time clickable to this link. */
+    protected $messageLink;
 
     /** @var bool Causes the image, audio, and video sections to be hiding when collapsed is true. */
     protected $collapsed = false;
 
-    /** @var string Name of the author. */
-    protected $authorName = '';
+    /** @var string|null Name of the author. */
+    protected $authorName;
 
-    /** @var string Providing this makes the author name clickable and points to this link. */
-    protected $authorLink = '';
+    /** @var string|null Providing this makes the author name clickable and points to this link. */
+    protected $authorLink;
 
-    /** @var string Displays a tiny icon to the left of the Author’s name. */
-    protected $authorIcon = '';
+    /** @var string|null Displays a tiny icon to the left of the Author’s name. */
+    protected $authorIcon;
 
-    /** @var string Title to display for this attachment, displays under the author. */
-    protected $title = '';
+    /** @var string|null Title to display for this attachment, displays under the author. */
+    protected $title;
 
-    /** @var string Providing this makes the title clickable, pointing to this link. */
-    protected $titleLink = '';
+    /** @var string|null Providing this makes the title clickable, pointing to this link. */
+    protected $titleLink;
 
     /** @var bool When this is true, a download icon appears and clicking this saves the link to file. */
     protected $titleLinkDownload = false;
 
-    /** @var string The image to display, will be “big” and easy to see. */
-    protected $imageUrl = '';
+    /** @var string|null The image to display, will be “big” and easy to see. */
+    protected $imageUrl;
 
-    /** @var string Audio file to play, only supports what html audio does. */
-    protected $audioUrl = '';
+    /** @var string|null Audio file to play, only supports what html audio does. */
+    protected $audioUrl;
 
-    /** @var string Video file to play, only supports what html video does. */
-    protected $videoUrl = '';
+    /** @var string|null Video file to play, only supports what html video does. */
+    protected $videoUrl;
 
     /** @var array An array of Attachment Field Objects. */
     protected $fields = [];
@@ -73,7 +73,7 @@ class RocketChatAttachment
      * Create a new instance of RocketChatAttachment.
      *
      * @param array $data
-     * @return RocketChatAttachment
+     * @return \NotificationChannels\RocketChat\RocketChatAttachment
      */
     public static function make(array $data = [])
     {
@@ -82,7 +82,7 @@ class RocketChatAttachment
 
     /**
      * @param string $color
-     * @return RocketChatAttachment
+     * @return \NotificationChannels\RocketChat\RocketChatAttachment
      */
     public function color(string $color): self
     {

--- a/src/RocketChatAttachment.php
+++ b/src/RocketChatAttachment.php
@@ -62,22 +62,22 @@ class RocketChatAttachment
     /**
      * RocketChatAttachment constructor.
      *
-     * @param array $config
+     * @param array $data
      */
-    public function __construct(array $config = [])
+    public function __construct(array $data = [])
     {
-        $this->setFromArray($config);
+        $this->setPropertiesFromArray($data);
     }
 
     /**
      * Create a new instance of RocketChatAttachment.
      *
-     * @param array $config
+     * @param array $data
      * @return RocketChatAttachment
      */
-    public static function make(array $config = [])
+    public static function make(array $data = [])
     {
-        return new self($config);
+        return new self($data);
     }
 
     /**
@@ -307,18 +307,18 @@ class RocketChatAttachment
     }
 
     /**
-     * Set attachment data form array.
+     * Set attachment data from array.
      *
      * @param array $data
      */
-    protected function setFromArray(array $data)
+    private function setPropertiesFromArray(array $data)
     {
         foreach ($data as $key => $value) {
-            $method = Str::camel($key);
-            if (! method_exists($this, $method)) {
+            $methodName = Str::camel($key);
+            if (! method_exists($this, $methodName)) {
                 continue;
             }
-            $this->{$method}($value);
+            $this->{$methodName}($value);
         }
     }
 }

--- a/src/RocketChatAttachment.php
+++ b/src/RocketChatAttachment.php
@@ -116,6 +116,7 @@ class RocketChatAttachment
             $date = clone $timestamp;
             $timestamp = $date->setTimezone(new DateTimeZone('UTC'))->format('Y-m-d\TH:i:s.v\Z');
         }
+
         $this->timestamp = $timestamp;
 
         return $this;
@@ -316,9 +317,11 @@ class RocketChatAttachment
     {
         foreach ($data as $key => $value) {
             $methodName = Str::camel($key);
+
             if (! method_exists($this, $methodName)) {
                 continue;
             }
+
             $this->{$methodName}($value);
         }
     }

--- a/src/RocketChatMessage.php
+++ b/src/RocketChatMessage.php
@@ -6,26 +6,26 @@ namespace NotificationChannels\RocketChat;
 
 class RocketChatMessage
 {
-    /** @var string RocketChat channel id. */
-    public $channel = '';
+    /** @var string|null RocketChat channel id. */
+    protected $channel = null;
 
-    /** @var string A user or app access token. */
-    public $from = '';
+    /** @var string|null A user or app access token. */
+    protected $from = null;
 
     /** @var string The text content of the message. */
-    public $content = '';
+    protected $content;
 
     /** @var string The alias name of the message. */
-    public $alias = '';
+    protected $alias;
 
     /** @var string The avatar emoji of the message. */
-    public $emoji = '';
+    protected $emoji;
 
     /** @var string The avatar image of the message. */
-    public $avatar = '';
+    protected $avatar;
 
     /** @var \NotificationChannels\RocketChat\RocketChatAttachment[] Attachments of the message. */
-    public $attachments = [];
+    protected $attachments = [];
 
     /**
      * Create a new instance of RocketChatMessage.
@@ -46,6 +46,16 @@ class RocketChatMessage
     public function __construct(string $content = '')
     {
         $this->content($content);
+    }
+
+    public function getChannel(): ?string
+    {
+        return $this->channel;
+    }
+
+    public function getFrom(): ?string
+    {
+        return $this->from;
     }
 
     /**

--- a/src/RocketChatMessage.php
+++ b/src/RocketChatMessage.php
@@ -33,7 +33,7 @@ class RocketChatMessage
      * @param  string $content
      * @return static
      */
-    public static function create(string $content = ''): self
+    public static function make(string $content = ''): self
     {
         return new static($content);
     }

--- a/src/RocketChatWebhookChannel.php
+++ b/src/RocketChatWebhookChannel.php
@@ -40,11 +40,13 @@ final class RocketChatWebhookChannel
         $message = $notification->toRocketChat($notifiable);
 
         $to = $message->getChannel() ?: $notifiable->routeNotificationFor('RocketChat');
-        if (! $to = $to ?: $this->rocketChat->getDefaultChannel()) {
+        $to = $to ?: $this->rocketChat->getDefaultChannel();
+        if ($to === null) {
             throw CouldNotSendNotification::missingTo();
         }
 
-        if (! $from = $message->getFrom() ?: $this->rocketChat->getToken()) {
+        $from = $message->getFrom() ?: $this->rocketChat->getToken();
+        if (! $from) {
             throw CouldNotSendNotification::missingFrom();
         }
 

--- a/src/RocketChatWebhookChannel.php
+++ b/src/RocketChatWebhookChannel.php
@@ -41,7 +41,7 @@ final class RocketChatWebhookChannel
         $message = $notification->toRocketChat($notifiable);
 
         $to = $message->channel ?: $notifiable->routeNotificationFor('RocketChat');
-        if (! $to = $to ?: $this->rocketChat->channel()) {
+        if (! $to = $to ?: $this->rocketChat->defaultChannel()) {
             throw CouldNotSendNotification::missingTo();
         }
 

--- a/src/RocketChatWebhookChannel.php
+++ b/src/RocketChatWebhookChannel.php
@@ -8,7 +8,6 @@ use Exception;
 use GuzzleHttp\Exception\ClientException;
 use Illuminate\Notifications\Notification;
 use NotificationChannels\RocketChat\Exceptions\CouldNotSendNotification;
-use Psr\Http\Message\ResponseInterface;
 
 final class RocketChatWebhookChannel
 {
@@ -41,11 +40,11 @@ final class RocketChatWebhookChannel
         $message = $notification->toRocketChat($notifiable);
 
         $to = $message->getChannel() ?: $notifiable->routeNotificationFor('RocketChat');
-        if (! $to = $to ?: $this->rocketChat->defaultChannel()) {
+        if (! $to = $to ?: $this->rocketChat->getDefaultChannel()) {
             throw CouldNotSendNotification::missingTo();
         }
 
-        if (! $from = $message->getFrom() ?: $this->rocketChat->token()) {
+        if (! $from = $message->getFrom() ?: $this->rocketChat->getToken()) {
             throw CouldNotSendNotification::missingFrom();
         }
 
@@ -61,10 +60,10 @@ final class RocketChatWebhookChannel
     /**
      * @param  string  $to
      * @param  \NotificationChannels\RocketChat\RocketChatMessage  $message
-     * @return \Psr\Http\Message\ResponseInterface
+     * @return void
      */
-    private function sendMessage(string $to, RocketChatMessage $message): ResponseInterface
+    private function sendMessage(string $to, RocketChatMessage $message): void
     {
-        return $this->rocketChat->sendMessage($to, $message->toArray());
+        $this->rocketChat->sendMessage($to, $message->toArray());
     }
 }

--- a/src/RocketChatWebhookChannel.php
+++ b/src/RocketChatWebhookChannel.php
@@ -40,12 +40,12 @@ final class RocketChatWebhookChannel
         /** @var \NotificationChannels\RocketChat\RocketChatMessage $message */
         $message = $notification->toRocketChat($notifiable);
 
-        $to = $message->channel ?: $notifiable->routeNotificationFor('RocketChat');
+        $to = $message->getChannel() ?: $notifiable->routeNotificationFor('RocketChat');
         if (! $to = $to ?: $this->rocketChat->defaultChannel()) {
             throw CouldNotSendNotification::missingTo();
         }
 
-        if (! $from = $message->from ?: $this->rocketChat->token()) {
+        if (! $from = $message->getFrom() ?: $this->rocketChat->token()) {
             throw CouldNotSendNotification::missingFrom();
         }
 

--- a/tests/RocketChatAttachmentTest.php
+++ b/tests/RocketChatAttachmentTest.php
@@ -20,7 +20,7 @@ final class RocketChatAttachmentTest extends TestCase
     /** @test */
     public function it_can_accept_a_config_when_creating_an_attachment(): void
     {
-        $attachment = RocketChatAttachment::create(['title' => 'test123']);
+        $attachment = RocketChatAttachment::make(['title' => 'test123']);
 
         $this->assertEquals(['title' => 'test123'], $attachment->toArray());
     }

--- a/tests/RocketChatMessageTest.php
+++ b/tests/RocketChatMessageTest.php
@@ -21,7 +21,7 @@ final class RocketChatMessageTest extends TestCase
     /** @test */
     public function it_can_accept_a_content_when_creating_a_message(): void
     {
-        $message = RocketChatMessage::create('hello');
+        $message = RocketChatMessage::make('hello');
 
         $this->assertEquals('hello', $message->content);
     }
@@ -77,7 +77,7 @@ final class RocketChatMessageTest extends TestCase
     /** @test */
     public function it_can_set_attachment(): void
     {
-        $attachment = RocketChatAttachment::create(['title' => 'test']);
+        $attachment = RocketChatAttachment::make(['title' => 'test']);
         $message = (new RocketChatMessage())->attachment($attachment);
 
         $this->assertSame($attachment, $message->attachments[0]);
@@ -94,9 +94,9 @@ final class RocketChatMessageTest extends TestCase
     public function it_can_set_multiple_attachments(): void
     {
         $message = (new RocketChatMessage())->attachments([
-            RocketChatAttachment::create(),
-            RocketChatAttachment::create(),
-            RocketChatAttachment::create(),
+            RocketChatAttachment::make(),
+            RocketChatAttachment::make(),
+            RocketChatAttachment::make(),
         ]);
         $this->assertInstanceOf(RocketChatAttachment::class, $message->attachments[0]);
         $this->assertCount(3, $message->attachments);
@@ -106,9 +106,9 @@ final class RocketChatMessageTest extends TestCase
     public function it_can_clear_attachments(): void
     {
         $message = (new RocketChatMessage())->attachments([
-            RocketChatAttachment::create(),
-            RocketChatAttachment::create(),
-            RocketChatAttachment::create(),
+            RocketChatAttachment::make(),
+            RocketChatAttachment::make(),
+            RocketChatAttachment::make(),
         ]);
 
         $message->clearAttachments();

--- a/tests/RocketChatMessageTest.php
+++ b/tests/RocketChatMessageTest.php
@@ -13,49 +13,49 @@ final class RocketChatMessageTest extends TestCase
     /** @test */
     public function it_can_accept_a_content_when_constructing_a_message(): void
     {
-        $message = new RocketChatMessage('hello');
+        $message = new RocketChatMessage('test-content');
 
-        $this->assertEquals('hello', $message->content);
+        $this->assertSame(['text' => 'test-content'], $message->toArray());
     }
 
     /** @test */
     public function it_can_accept_a_content_when_creating_a_message(): void
     {
-        $message = RocketChatMessage::make('hello');
+        $message = RocketChatMessage::make('test-content');
 
-        $this->assertEquals('hello', $message->content);
+        $this->assertSame(['text' => 'test-content'], $message->toArray());
     }
 
     /** @test */
     public function it_can_set_the_content(): void
     {
-        $message = (new RocketChatMessage())->content('hello');
+        $message = (new RocketChatMessage())->content('test-content');
 
-        $this->assertEquals('hello', $message->content);
+        $this->assertSame(['text' => 'test-content'], $message->toArray());
     }
 
     /** @test */
     public function it_can_set_the_channel(): void
     {
-        $message = (new RocketChatMessage())->to('channel');
+        $message = (new RocketChatMessage())->to('test-channel');
 
-        $this->assertEquals('channel', $message->channel);
+        $this->assertSame('test-channel', $message->getChannel());
     }
 
     /** @test */
     public function it_can_set_the_from(): void
     {
-        $message = (new RocketChatMessage())->from('token');
+        $message = (new RocketChatMessage())->from('test-token');
 
-        $this->assertEquals('token', $message->from);
+        $this->assertSame('test-token', $message->getFrom());
     }
 
     /** @test */
     public function it_can_set_the_alias(): void
     {
-        $message = (new RocketChatMessage())->alias('alias');
+        $message = (new RocketChatMessage())->alias('test-alias');
 
-        $this->assertEquals('alias', $message->alias);
+        $this->assertSame(['alias' => 'test-alias'], $message->toArray());
     }
 
     /** @test */
@@ -63,7 +63,7 @@ final class RocketChatMessageTest extends TestCase
     {
         $message = (new RocketChatMessage())->emoji(':emoji:');
 
-        $this->assertEquals(':emoji:', $message->emoji);
+        $this->assertSame(['emoji' => ':emoji:'], $message->toArray());
     }
 
     /** @test */
@@ -71,7 +71,7 @@ final class RocketChatMessageTest extends TestCase
     {
         $message = (new RocketChatMessage())->avatar('avatar_img');
 
-        $this->assertEquals('avatar_img', $message->avatar);
+        $this->assertSame(['avatar' => 'avatar_img'], $message->toArray());
     }
 
     /** @test */
@@ -80,14 +80,15 @@ final class RocketChatMessageTest extends TestCase
         $attachment = RocketChatAttachment::make(['title' => 'test']);
         $message = (new RocketChatMessage())->attachment($attachment);
 
-        $this->assertSame($attachment, $message->attachments[0]);
+        $this->assertSame($attachment->toArray(), $message->toArray()['attachments'][0]);
     }
 
     /** @test */
     public function it_can_set_attachment_as_array(): void
     {
         $message = (new RocketChatMessage())->attachment(['title' => 'test']);
-        $this->assertInstanceOf(RocketChatAttachment::class, $message->attachments[0]);
+
+        $this->assertSame(['title' => 'test'], $message->toArray()['attachments'][0]);
     }
 
     /** @test */
@@ -98,8 +99,8 @@ final class RocketChatMessageTest extends TestCase
             RocketChatAttachment::make(),
             RocketChatAttachment::make(),
         ]);
-        $this->assertInstanceOf(RocketChatAttachment::class, $message->attachments[0]);
-        $this->assertCount(3, $message->attachments);
+
+        $this->assertCount(3, $message->toArray()['attachments']);
     }
 
     /** @test */
@@ -112,6 +113,7 @@ final class RocketChatMessageTest extends TestCase
         ]);
 
         $message->clearAttachments();
-        $this->assertCount(0, $message->attachments);
+
+        $this->assertArrayNotHasKey('attachments', $message->toArray());
     }
 }

--- a/tests/RocketChatWebhookChannelTest.php
+++ b/tests/RocketChatWebhookChannelTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace NotificationChannels\RocketChat\Test;
 
-use GuzzleHttp\Client;
+use GuzzleHttp\Client as GuzzleHttpClient;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Notifications\Notification;
@@ -23,7 +23,7 @@ final class RocketChatWebhookChannelTest extends TestCase
     /** @test */
     public function it_can_send_a_notification(): void
     {
-        $client = Mockery::mock(Client::class);
+        $client = Mockery::mock(GuzzleHttpClient::class);
 
         $apiBaseUrl = 'http://localhost:3000';
         $token = ':token';
@@ -48,7 +48,7 @@ final class RocketChatWebhookChannelTest extends TestCase
     /** @test */
     public function it_handles_generic_errors(): void
     {
-        $client = Mockery::mock(Client::class);
+        $client = Mockery::mock(GuzzleHttpClient::class);
         $this->expectException(CouldNotSendNotification::class);
 
         $apiBaseUrl = 'http://localhost:3000';
@@ -76,7 +76,7 @@ final class RocketChatWebhookChannelTest extends TestCase
     {
         $this->expectException(CouldNotSendNotification::class);
 
-        $rocketChat = new RocketChat(new Client(), '', '', '');
+        $rocketChat = new RocketChat(new GuzzleHttpClient(), '', '', '');
         $channel = new RocketChatWebhookChannel($rocketChat);
         $channel->send(new TestNotifiable(), new TestNotificationWithMissedChannel());
     }
@@ -86,7 +86,7 @@ final class RocketChatWebhookChannelTest extends TestCase
     {
         $this->expectException(CouldNotSendNotification::class);
 
-        $rocketChat = new RocketChat(new Client(), '', '', '');
+        $rocketChat = new RocketChat(new GuzzleHttpClient(), '', '', '');
         $channel = new RocketChatWebhookChannel($rocketChat);
         $channel->send(new TestNotifiable(), new TestNotificationWithMissedFrom());
     }

--- a/tests/RocketChatWebhookChannelTest.php
+++ b/tests/RocketChatWebhookChannelTest.php
@@ -106,7 +106,7 @@ class TestNotification extends Notification
 {
     public function toRocketChat(): RocketChatMessage
     {
-        return RocketChatMessage::create('hello')->from(':token')->to(':channel');
+        return RocketChatMessage::make('hello')->from(':token')->to(':channel');
     }
 }
 
@@ -114,7 +114,7 @@ class TestNotificationWithMissedChannel extends Notification
 {
     public function toRocketChat(): RocketChatMessage
     {
-        return RocketChatMessage::create('hello')->from(':token');
+        return RocketChatMessage::make('hello')->from(':token');
     }
 }
 
@@ -122,6 +122,6 @@ class TestNotificationWithMissedFrom extends Notification
 {
     public function toRocketChat(): RocketChatMessage
     {
-        return RocketChatMessage::create('hello')->to(':channel');
+        return RocketChatMessage::make('hello')->to(':channel');
     }
 }


### PR DESCRIPTION
This PR contains:
- renaming `create` static methods to `make` because all it does - instantiates (making) new instance, and not persisting (creating) anything;
- renaming `RocketChat::channel()` to `RocketChat::getDefaultChannel()` to make its meaning more explicit;
- renaming `RocketChatAttachment::setFromArray` to `RocketChatAttachment::setPropertiesFromArray` to make its meaning more explicit;
- adds `get` prefix to all accessor methods;
- drops `RocketChat::url()` accessor since it's not meant to be used outside of the class.