### PR TITLE
Allow RocketChatAttachment class accept DateTimeImmutable as timestamp argument

### DIFF
--- a/src/RocketChatAttachment.php
+++ b/src/RocketChatAttachment.php
@@ -119,8 +119,7 @@ class RocketChatAttachment
         }
 
         if ($timestamp instanceof DateTimeInterface) {
-            $date = clone $timestamp;
-            $timestamp = $date->format(DateTimeInterface::ATOM);
+            $timestamp = $timestamp->format(DateTimeInterface::ATOM);
         }
 
         $this->timestamp = $timestamp;

--- a/src/RocketChatAttachment.php
+++ b/src/RocketChatAttachment.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace NotificationChannels\RocketChat;
 
 use DateTimeInterface;
-use DateTimeZone;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 

--- a/src/RocketChatAttachment.php
+++ b/src/RocketChatAttachment.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace NotificationChannels\RocketChat;
 
-use DateTime;
+use DateTimeInterface;
 use DateTimeZone;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
@@ -103,23 +103,23 @@ class RocketChatAttachment
     }
 
     /**
-     * @param string|\DateTime $timestamp
+     * @param string|\DateTimeInterface $timestamp
      * @return \NotificationChannels\RocketChat\RocketChatAttachment
      */
     public function timestamp($timestamp): self
     {
-        if (! ($timestamp instanceof DateTime) && ! is_string($timestamp)) {
-            $invalidType = gettype($timestamp);
-            if ($invalidType === 'object') {
-                $invalidType = get_class($timestamp);
-            }
+        if (! ($timestamp instanceof DateTimeInterface) && ! is_string($timestamp)) {
+            $invalidType = is_object($timestamp)
+                ? get_class($timestamp)
+                : gettype($timestamp);
+
             throw new InvalidArgumentException(sprintf(
                 'Timestamp must be string or DateTime, %s given.',
                 $invalidType
             ));
         }
 
-        if ($timestamp instanceof DateTime) {
+        if ($timestamp instanceof DateTimeInterface) {
             $date = clone $timestamp;
             $timestamp = $date->setTimezone(new DateTimeZone('UTC'))->format('Y-m-d\TH:i:s.v\Z');
         }

--- a/src/RocketChatAttachment.php
+++ b/src/RocketChatAttachment.php
@@ -109,7 +109,10 @@ class RocketChatAttachment
     public function timestamp($timestamp): self
     {
         if (! ($timestamp instanceof DateTime) && ! is_string($timestamp)) {
-            throw new InvalidArgumentException('Timestamp must be string or DateTime, '.gettype($timestamp).' given.');
+            throw new InvalidArgumentException(sprintf(
+                'Timestamp must be string or DateTime, %s given.',
+                get_class($timestamp)
+            ));
         }
 
         if ($timestamp instanceof DateTime) {

--- a/src/RocketChatAttachment.php
+++ b/src/RocketChatAttachment.php
@@ -119,7 +119,7 @@ class RocketChatAttachment
         }
 
         if ($timestamp instanceof DateTimeInterface) {
-            $timestamp = $timestamp->format(DateTimeInterface::ATOM);
+            $timestamp = $timestamp->format(DateTimeInterface::RFC3339);
         }
 
         $this->timestamp = $timestamp;

--- a/src/RocketChatAttachment.php
+++ b/src/RocketChatAttachment.php
@@ -109,9 +109,13 @@ class RocketChatAttachment
     public function timestamp($timestamp): self
     {
         if (! ($timestamp instanceof DateTime) && ! is_string($timestamp)) {
+            $invalidType = gettype($timestamp);
+            if ($invalidType === 'object') {
+                $invalidType = get_class($timestamp);
+            }
             throw new InvalidArgumentException(sprintf(
                 'Timestamp must be string or DateTime, %s given.',
-                get_class($timestamp)
+                $invalidType
             ));
         }
 

--- a/src/RocketChatAttachment.php
+++ b/src/RocketChatAttachment.php
@@ -121,7 +121,7 @@ class RocketChatAttachment
 
         if ($timestamp instanceof DateTimeInterface) {
             $date = clone $timestamp;
-            $timestamp = $date->setTimezone(new DateTimeZone('UTC'))->format('Y-m-d\TH:i:s.v\Z');
+            $timestamp = $date->format(DateTimeInterface::ATOM);
         }
 
         $this->timestamp = $timestamp;

--- a/tests/RocketChatAttachmentTest.php
+++ b/tests/RocketChatAttachmentTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace NotificationChannels\RocketChat\Test;
 
+use DateTime;
+use DateTimeImmutable;
 use NotificationChannels\RocketChat\RocketChatAttachment;
 use PHPUnit\Framework\TestCase;
 
@@ -63,11 +65,21 @@ final class RocketChatAttachmentTest extends TestCase
     /** @test */
     public function it_can_set_the_timestamp_as_datetime(): void
     {
-        $date = \DateTime::createFromFormat('Y-m-d H:i:s.u', '2020-02-19 19:00:00.000');
+        $date = DateTime::createFromFormat('Y-m-d H:i:s.u', '2020-02-19 19:00:00.000');
         $attachment = new RocketChatAttachment();
         $attachment->timestamp($date);
 
         $this->assertEquals(['ts' => '2020-02-19T19:00:00.000Z'], $attachment->toArray());
+    }
+
+    /** @test */
+    public function it_can_set_the_timestamp_as_immutable_datetime(): void
+    {
+        $date = DateTimeImmutable::createFromFormat('Y-m-d H:i:s.u', '2020-02-19 19:00:00.000');
+        $attachment = new RocketChatAttachment();
+        $attachment->timestamp($date);
+
+        $this->assertSame(['ts' => '2020-02-19T19:00:00.000Z'], $attachment->toArray());
     }
 
     /** @test */

--- a/tests/RocketChatAttachmentTest.php
+++ b/tests/RocketChatAttachmentTest.php
@@ -6,10 +6,10 @@ namespace NotificationChannels\RocketChat\Test;
 
 use DateTime;
 use DateTimeImmutable;
+use DateTimeInterface;
 use InvalidArgumentException;
 use NotificationChannels\RocketChat\RocketChatAttachment;
 use PHPUnit\Framework\TestCase;
-use DateTimeInterface;
 
 final class RocketChatAttachmentTest extends TestCase
 {

--- a/tests/RocketChatAttachmentTest.php
+++ b/tests/RocketChatAttachmentTest.php
@@ -9,6 +9,7 @@ use DateTimeImmutable;
 use InvalidArgumentException;
 use NotificationChannels\RocketChat\RocketChatAttachment;
 use PHPUnit\Framework\TestCase;
+use DateTimeInterface;
 
 final class RocketChatAttachmentTest extends TestCase
 {
@@ -70,7 +71,7 @@ final class RocketChatAttachmentTest extends TestCase
         $attachment = new RocketChatAttachment();
         $attachment->timestamp($date);
 
-        $this->assertEquals(['ts' => '2020-02-19T19:00:00.000Z'], $attachment->toArray());
+        $this->assertEquals(['ts' => $date->format(DateTimeInterface::ATOM)], $attachment->toArray());
     }
 
     /** @test */
@@ -80,7 +81,7 @@ final class RocketChatAttachmentTest extends TestCase
         $attachment = new RocketChatAttachment();
         $attachment->timestamp($date);
 
-        $this->assertSame(['ts' => '2020-02-19T19:00:00.000Z'], $attachment->toArray());
+        $this->assertSame(['ts' => $date->format(DateTimeInterface::ATOM)], $attachment->toArray());
     }
 
     /** @test */

--- a/tests/RocketChatAttachmentTest.php
+++ b/tests/RocketChatAttachmentTest.php
@@ -6,6 +6,7 @@ namespace NotificationChannels\RocketChat\Test;
 
 use DateTime;
 use DateTimeImmutable;
+use InvalidArgumentException;
 use NotificationChannels\RocketChat\RocketChatAttachment;
 use PHPUnit\Framework\TestCase;
 
@@ -80,6 +81,16 @@ final class RocketChatAttachmentTest extends TestCase
         $attachment->timestamp($date);
 
         $this->assertSame(['ts' => '2020-02-19T19:00:00.000Z'], $attachment->toArray());
+    }
+
+    /** @test */
+    public function it_cannot_set_the_timestamp_as_integer(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $date = 1234567890;
+        $attachment = new RocketChatAttachment();
+        $attachment->timestamp($date);
     }
 
     /** @test */


### PR DESCRIPTION
This PR adds failing tests for DateTimeImmutable timestamp. This need to be fixed.