### PR TITLE
Revert renaming static factory method create to make

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,6 @@ All notable changes to `laravel-notification-channels/rocket-chat` will be docum
 
 - ([#7]) Method `channel` renamed to `getDefaultChannel` in `NotificationChannels\RocketChat\RocketChat` class
 - ([#7]) Method `token` renamed to `getToken` in `NotificationChannels\RocketChat\RocketChat` class
-- ([#7]) Method `create` renamed to `make` in `NotificationChannels\RocketChat\RocketChatMessage` class
-- ([#7]) Method `create` renamed to `make` in `NotificationChannels\RocketChat\RocketChatAttachment` class
 - ([#7]) Method `setFromArray` renamed to `setPropertiesFromArray` in `NotificationChannels\RocketChat\RocketChatAttachment` class
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ class TaskCompleted extends Notification
 
     public function toRocketChat($notifiable): RocketChatMessage
     {
-        return RocketChatMessage::make('Test message')
+        return RocketChatMessage::create('Test message')
             ->to('channel_name') // optional if set in config
             ->from('webhook_token'); // optional if set in config
     }
@@ -118,12 +118,12 @@ There are several ways to add one ore more attachments to a message
 ```php
 public function toRocketChat($notifiable)
 {
-    return RocketChatMessage::make('Test message')
+    return RocketChatMessage::create('Test message')
         ->to('channel_name') // optional if set in config
         ->from('webhook_token') // optional if set in config
         ->attachments([
-            RocketChatAttachment::make()->imageUrl('test'),
-            RocketChatAttachment::make(['image_url' => 'test']),
+            RocketChatAttachment::create()->imageUrl('test'),
+            RocketChatAttachment::create(['image_url' => 'test']),
             new RocketChatAttachment(['image_url' => 'test']),
             [
                 'image_url' => 'test'

--- a/src/RocketChatAttachment.php
+++ b/src/RocketChatAttachment.php
@@ -74,7 +74,7 @@ class RocketChatAttachment
      * @param array $data
      * @return \NotificationChannels\RocketChat\RocketChatAttachment
      */
-    public static function make(array $data = [])
+    public static function create(array $data = [])
     {
         return new self($data);
     }

--- a/src/RocketChatMessage.php
+++ b/src/RocketChatMessage.php
@@ -33,7 +33,7 @@ class RocketChatMessage
      * @param  string $content
      * @return static
      */
-    public static function make(string $content = ''): self
+    public static function create(string $content = ''): self
     {
         return new static($content);
     }

--- a/tests/RocketChatAttachmentTest.php
+++ b/tests/RocketChatAttachmentTest.php
@@ -24,7 +24,7 @@ final class RocketChatAttachmentTest extends TestCase
     /** @test */
     public function it_can_accept_a_config_when_creating_an_attachment(): void
     {
-        $attachment = RocketChatAttachment::make(['title' => 'test123']);
+        $attachment = RocketChatAttachment::create(['title' => 'test123']);
 
         $this->assertEquals(['title' => 'test123'], $attachment->toArray());
     }

--- a/tests/RocketChatMessageTest.php
+++ b/tests/RocketChatMessageTest.php
@@ -21,7 +21,7 @@ final class RocketChatMessageTest extends TestCase
     /** @test */
     public function it_can_accept_a_content_when_creating_a_message(): void
     {
-        $message = RocketChatMessage::make('test-content');
+        $message = RocketChatMessage::create('test-content');
 
         $this->assertSame(['text' => 'test-content'], $message->toArray());
     }
@@ -77,7 +77,7 @@ final class RocketChatMessageTest extends TestCase
     /** @test */
     public function it_can_set_attachment(): void
     {
-        $attachment = RocketChatAttachment::make(['title' => 'test']);
+        $attachment = RocketChatAttachment::create(['title' => 'test']);
         $message = (new RocketChatMessage())->attachment($attachment);
 
         $this->assertSame($attachment->toArray(), $message->toArray()['attachments'][0]);
@@ -95,9 +95,9 @@ final class RocketChatMessageTest extends TestCase
     public function it_can_set_multiple_attachments(): void
     {
         $message = (new RocketChatMessage())->attachments([
-            RocketChatAttachment::make(),
-            RocketChatAttachment::make(),
-            RocketChatAttachment::make(),
+            RocketChatAttachment::create(),
+            RocketChatAttachment::create(),
+            RocketChatAttachment::create(),
         ]);
 
         $this->assertCount(3, $message->toArray()['attachments']);

--- a/tests/RocketChatWebhookChannelTest.php
+++ b/tests/RocketChatWebhookChannelTest.php
@@ -106,7 +106,7 @@ class TestNotification extends Notification
 {
     public function toRocketChat(): RocketChatMessage
     {
-        return RocketChatMessage::make('hello')->from(':token')->to(':channel');
+        return RocketChatMessage::create('hello')->from(':token')->to(':channel');
     }
 }
 
@@ -114,7 +114,7 @@ class TestNotificationWithMissedChannel extends Notification
 {
     public function toRocketChat(): RocketChatMessage
     {
-        return RocketChatMessage::make('hello')->from(':token');
+        return RocketChatMessage::create('hello')->from(':token');
     }
 }
 
@@ -122,6 +122,6 @@ class TestNotificationWithMissedFrom extends Notification
 {
     public function toRocketChat(): RocketChatMessage
     {
-        return RocketChatMessage::make('hello')->to(':channel');
+        return RocketChatMessage::create('hello')->to(':channel');
     }
 }


### PR DESCRIPTION
Static factory method `create` was renamed to `make` in #7 
For sake of code identity with other channels I'm reverting this change.