### PR TITLE
Laravel 10 & 11 support + PHPUnit 11 migration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /vendor
 /build
 /.idea
+.phpunit.cache
 .phpunit.result.cache
 composer.phar
 composer.lock

--- a/composer.json
+++ b/composer.json
@@ -22,13 +22,13 @@
     "require": {
         "php": "^7.2.0|^8.0",
         "guzzlehttp/guzzle": "^6.3|^7.0",
-        "illuminate/notifications": "^5.6|^6.0|^7.0|^8.0|^9.0",
-        "illuminate/queue": "^5.6|^6.0|^7.0|^8.0|^9.0",
-        "illuminate/support": "^5.6|^6.0|^7.0|^8.0|^9.0"
+        "illuminate/notifications": "^5.6|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
+        "illuminate/queue": "^5.6|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
+        "illuminate/support": "^5.6|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.3.3",
-        "phpunit/phpunit": "^8.0|^9.0"
+        "phpunit/phpunit": "^8.0|^9.0|^10.0|^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.3.3",
-        "phpunit/phpunit": "^8.0|^9.0|^10.0|^11.0"
+        "phpunit/phpunit": "^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,28 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="vendor/autoload.php"
          backupGlobals="false"
-         backupStaticAttributes="false"
          colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="RocketChat Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
+         stopOnFailure="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.1/phpunit.xsd"
+         cacheDirectory=".phpunit.cache"
+         backupStaticProperties="false">
+  <coverage>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+      <html outputDirectory="build/coverage"/>
+      <text outputFile="build/coverage.txt"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="RocketChat Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <junit outputFile="build/report.junit.xml"/>
+  </logging>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/tests/RocketChatAttachmentTest.php
+++ b/tests/RocketChatAttachmentTest.php
@@ -13,32 +13,28 @@ use PHPUnit\Framework\TestCase;
 
 final class RocketChatAttachmentTest extends TestCase
 {
-    /** @test */
-    public function it_can_accept_a_config_when_constructing_an_attachment(): void
+    public function test_it_can_accept_a_config_when_constructing_an_attachment(): void
     {
         $attachment = new RocketChatAttachment(['title' => 'test123']);
 
         $this->assertEquals(['title' => 'test123'], $attachment->toArray());
     }
 
-    /** @test */
-    public function it_can_accept_a_config_when_creating_an_attachment(): void
+    public function test_it_can_accept_a_config_when_creating_an_attachment(): void
     {
         $attachment = RocketChatAttachment::create(['title' => 'test123']);
 
         $this->assertEquals(['title' => 'test123'], $attachment->toArray());
     }
 
-    /** @test */
-    public function it_returns_an_empty_array_if_not_configured(): void
+    public function test_it_returns_an_empty_array_if_not_configured(): void
     {
         $attachment = new RocketChatAttachment();
 
         $this->assertEquals([], $attachment->toArray());
     }
 
-    /** @test */
-    public function it_can_set_the_color(): void
+    public function test_it_can_set_the_color(): void
     {
         $attachment = new RocketChatAttachment();
         $attachment->color('#FFFFFF');
@@ -46,8 +42,7 @@ final class RocketChatAttachmentTest extends TestCase
         $this->assertEquals(['color' => '#FFFFFF'], $attachment->toArray());
     }
 
-    /** @test */
-    public function it_can_set_the_text(): void
+    public function test_it_can_set_the_text(): void
     {
         $attachment = new RocketChatAttachment();
         $attachment->text('test123');
@@ -55,8 +50,7 @@ final class RocketChatAttachmentTest extends TestCase
         $this->assertEquals(['text' => 'test123'], $attachment->toArray());
     }
 
-    /** @test */
-    public function it_can_set_the_timestamp(): void
+    public function test_it_can_set_the_timestamp(): void
     {
         $attachment = new RocketChatAttachment();
         $attachment->timestamp('2020-02-19T19:00:00.000Z');
@@ -64,8 +58,7 @@ final class RocketChatAttachmentTest extends TestCase
         $this->assertEquals(['ts' => '2020-02-19T19:00:00.000Z'], $attachment->toArray());
     }
 
-    /** @test */
-    public function it_can_set_the_timestamp_as_datetime(): void
+    public function test_it_can_set_the_timestamp_as_datetime(): void
     {
         $date = DateTime::createFromFormat('Y-m-d H:i:s.u', '2020-02-19 19:00:00.000');
         $attachment = new RocketChatAttachment();
@@ -74,8 +67,7 @@ final class RocketChatAttachmentTest extends TestCase
         $this->assertEquals(['ts' => $date->format(DateTimeInterface::ATOM)], $attachment->toArray());
     }
 
-    /** @test */
-    public function it_can_set_the_timestamp_as_immutable_datetime(): void
+    public function test_it_can_set_the_timestamp_as_immutable_datetime(): void
     {
         $date = DateTimeImmutable::createFromFormat('Y-m-d H:i:s.u', '2020-02-19 19:00:00.000');
         $attachment = new RocketChatAttachment();
@@ -84,8 +76,7 @@ final class RocketChatAttachmentTest extends TestCase
         $this->assertSame(['ts' => $date->format(DateTimeInterface::ATOM)], $attachment->toArray());
     }
 
-    /** @test */
-    public function it_cannot_set_the_timestamp_as_integer(): void
+    public function test_it_cannot_set_the_timestamp_as_integer(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
@@ -94,8 +85,7 @@ final class RocketChatAttachmentTest extends TestCase
         $attachment->timestamp($date);
     }
 
-    /** @test */
-    public function it_can_set_the_thumb_url(): void
+    public function test_it_can_set_the_thumb_url(): void
     {
         $attachment = new RocketChatAttachment();
         $attachment->thumbnailUrl('test123');
@@ -103,8 +93,7 @@ final class RocketChatAttachmentTest extends TestCase
         $this->assertEquals(['thumb_url' => 'test123'], $attachment->toArray());
     }
 
-    /** @test */
-    public function it_can_set_the_message_link(): void
+    public function test_it_can_set_the_message_link(): void
     {
         $attachment = new RocketChatAttachment();
         $attachment->messageLink('test123');
@@ -112,8 +101,7 @@ final class RocketChatAttachmentTest extends TestCase
         $this->assertEquals(['message_link' => 'test123'], $attachment->toArray());
     }
 
-    /** @test */
-    public function it_can_set_the_collapsed(): void
+    public function test_it_can_set_the_collapsed(): void
     {
         $attachment = new RocketChatAttachment();
         $attachment->collapsed(true);
@@ -121,8 +109,7 @@ final class RocketChatAttachmentTest extends TestCase
         $this->assertEquals(['collapsed' => true], $attachment->toArray());
     }
 
-    /** @test */
-    public function it_can_set_the_author_name(): void
+    public function test_it_can_set_the_author_name(): void
     {
         $attachment = new RocketChatAttachment();
         $attachment->authorName('author');
@@ -130,8 +117,7 @@ final class RocketChatAttachmentTest extends TestCase
         $this->assertEquals(['author_name' => 'author'], $attachment->toArray());
     }
 
-    /** @test */
-    public function it_can_set_the_author_link(): void
+    public function test_it_can_set_the_author_link(): void
     {
         $attachment = new RocketChatAttachment();
         $attachment->authorLink('test123');
@@ -139,8 +125,7 @@ final class RocketChatAttachmentTest extends TestCase
         $this->assertEquals(['author_link' => 'test123'], $attachment->toArray());
     }
 
-    /** @test */
-    public function it_can_set_the_author_icon(): void
+    public function test_it_can_set_the_author_icon(): void
     {
         $attachment = new RocketChatAttachment();
         $attachment->authorIcon('test123');
@@ -148,8 +133,7 @@ final class RocketChatAttachmentTest extends TestCase
         $this->assertEquals(['author_icon' => 'test123'], $attachment->toArray());
     }
 
-    /** @test */
-    public function it_can_set_the_author(): void
+    public function test_it_can_set_the_author(): void
     {
         $attachment = new RocketChatAttachment();
         $attachment->author('aname', 'alink', 'aicon');
@@ -161,8 +145,7 @@ final class RocketChatAttachmentTest extends TestCase
         ], $attachment->toArray());
     }
 
-    /** @test */
-    public function it_can_set_the_title(): void
+    public function test_it_can_set_the_title(): void
     {
         $attachment = new RocketChatAttachment();
         $attachment->title('test123');
@@ -170,8 +153,7 @@ final class RocketChatAttachmentTest extends TestCase
         $this->assertEquals(['title' => 'test123'], $attachment->toArray());
     }
 
-    /** @test */
-    public function it_can_set_the_title_link(): void
+    public function test_it_can_set_the_title_link(): void
     {
         $attachment = new RocketChatAttachment();
         $attachment->titleLink('test123');
@@ -179,8 +161,7 @@ final class RocketChatAttachmentTest extends TestCase
         $this->assertEquals(['title_link' => 'test123'], $attachment->toArray());
     }
 
-    /** @test */
-    public function it_can_set_the_title_link_download(): void
+    public function test_it_can_set_the_title_link_download(): void
     {
         $attachment = new RocketChatAttachment();
         $attachment->titleLinkDownload(true);
@@ -188,8 +169,7 @@ final class RocketChatAttachmentTest extends TestCase
         $this->assertEquals(['title_link_download' => true], $attachment->toArray());
     }
 
-    /** @test */
-    public function it_can_set_the_image_url(): void
+    public function test_it_can_set_the_image_url(): void
     {
         $attachment = new RocketChatAttachment();
         $attachment->imageUrl('test123');
@@ -197,8 +177,7 @@ final class RocketChatAttachmentTest extends TestCase
         $this->assertEquals(['image_url' => 'test123'], $attachment->toArray());
     }
 
-    /** @test */
-    public function it_can_set_the_audio_url(): void
+    public function test_it_can_set_the_audio_url(): void
     {
         $attachment = new RocketChatAttachment();
         $attachment->audioUrl('test123');
@@ -206,8 +185,7 @@ final class RocketChatAttachmentTest extends TestCase
         $this->assertEquals(['audio_url' => 'test123'], $attachment->toArray());
     }
 
-    /** @test */
-    public function it_can_set_the_video_url(): void
+    public function test_it_can_set_the_video_url(): void
     {
         $attachment = new RocketChatAttachment();
         $attachment->videoUrl('test123');
@@ -215,8 +193,7 @@ final class RocketChatAttachmentTest extends TestCase
         $this->assertEquals(['video_url' => 'test123'], $attachment->toArray());
     }
 
-    /** @test */
-    public function it_can_set_the_fields(): void
+    public function test_it_can_set_the_fields(): void
     {
         $fields = [
             [
@@ -236,8 +213,7 @@ final class RocketChatAttachmentTest extends TestCase
         $this->assertEquals(['fields' => $fields], $attachment->toArray());
     }
 
-    /** @test */
-    public function it_cannot_set_unknown_field(): void
+    public function test_it_cannot_set_unknown_field(): void
     {
         $attachment = new RocketChatAttachment(['notExisting']);
         $this->assertEquals([], $attachment->toArray());

--- a/tests/RocketChatMessageTest.php
+++ b/tests/RocketChatMessageTest.php
@@ -10,72 +10,63 @@ use PHPUnit\Framework\TestCase;
 
 final class RocketChatMessageTest extends TestCase
 {
-    /** @test */
-    public function it_can_accept_a_content_when_constructing_a_message(): void
+    public function test_it_can_accept_a_content_when_constructing_a_message(): void
     {
         $message = new RocketChatMessage('test-content');
 
         $this->assertSame(['text' => 'test-content'], $message->toArray());
     }
 
-    /** @test */
-    public function it_can_accept_a_content_when_creating_a_message(): void
+    public function test_it_can_accept_a_content_when_creating_a_message(): void
     {
         $message = RocketChatMessage::create('test-content');
 
         $this->assertSame(['text' => 'test-content'], $message->toArray());
     }
 
-    /** @test */
-    public function it_can_set_the_content(): void
+    public function test_it_can_set_the_content(): void
     {
         $message = (new RocketChatMessage())->content('test-content');
 
         $this->assertSame(['text' => 'test-content'], $message->toArray());
     }
 
-    /** @test */
-    public function it_can_set_the_channel(): void
+    public function test_it_can_set_the_channel(): void
     {
         $message = (new RocketChatMessage())->to('test-channel');
 
         $this->assertSame('test-channel', $message->getChannel());
     }
 
-    /** @test */
-    public function it_can_set_the_from(): void
+    public function test_it_can_set_the_from(): void
     {
         $message = (new RocketChatMessage())->from('test-token');
 
         $this->assertSame('test-token', $message->getFrom());
     }
 
-    /** @test */
-    public function it_can_set_the_alias(): void
+    public function test_it_can_set_the_alias(): void
     {
         $message = (new RocketChatMessage())->alias('test-alias');
 
         $this->assertSame(['alias' => 'test-alias'], $message->toArray());
     }
 
-    /** @test */
-    public function it_can_set_the_emoji(): void
+    public function test_it_can_set_the_emoji(): void
     {
         $message = (new RocketChatMessage())->emoji(':emoji:');
 
         $this->assertSame(['emoji' => ':emoji:'], $message->toArray());
     }
 
-    /** @test */
-    public function it_can_set_the_avatar(): void
+    public function test_it_can_set_the_avatar(): void
     {
         $message = (new RocketChatMessage())->avatar('avatar_img');
 
         $this->assertSame(['avatar' => 'avatar_img'], $message->toArray());
     }
 
-    /** @test */
-    public function it_can_set_attachment(): void
+    public function test_it_can_set_attachment(): void
     {
         $attachment = RocketChatAttachment::create(['title' => 'test']);
         $message = (new RocketChatMessage())->attachment($attachment);
@@ -83,16 +74,14 @@ final class RocketChatMessageTest extends TestCase
         $this->assertSame($attachment->toArray(), $message->toArray()['attachments'][0]);
     }
 
-    /** @test */
-    public function it_can_set_attachment_as_array(): void
+    public function test_it_can_set_attachment_as_array(): void
     {
         $message = (new RocketChatMessage())->attachment(['title' => 'test']);
 
         $this->assertSame(['title' => 'test'], $message->toArray()['attachments'][0]);
     }
 
-    /** @test */
-    public function it_can_set_multiple_attachments(): void
+    public function test_it_can_set_multiple_attachments(): void
     {
         $message = (new RocketChatMessage())->attachments([
             RocketChatAttachment::create(),

--- a/tests/RocketChatWebhookChannelTest.php
+++ b/tests/RocketChatWebhookChannelTest.php
@@ -20,8 +20,7 @@ final class RocketChatWebhookChannelTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
 
-    /** @test */
-    public function it_can_send_a_notification(): void
+    public function test_it_can_send_a_notification(): void
     {
         $client = Mockery::mock(GuzzleHttpClient::class);
 
@@ -45,8 +44,7 @@ final class RocketChatWebhookChannelTest extends TestCase
         $channel->send(new TestNotifiable(), new TestNotification());
     }
 
-    /** @test */
-    public function it_handles_generic_errors(): void
+    public function test_it_handles_generic_errors(): void
     {
         $client = Mockery::mock(GuzzleHttpClient::class);
         $this->expectException(CouldNotSendNotification::class);
@@ -71,8 +69,7 @@ final class RocketChatWebhookChannelTest extends TestCase
         $channel->send(new TestNotifiable(), new TestNotification());
     }
 
-    /** @test */
-    public function it_does_not_send_a_message_when_channel_missed(): void
+    public function test_it_does_not_send_a_message_when_channel_missed(): void
     {
         $this->expectException(CouldNotSendNotification::class);
 
@@ -81,8 +78,7 @@ final class RocketChatWebhookChannelTest extends TestCase
         $channel->send(new TestNotifiable(), new TestNotificationWithMissedChannel());
     }
 
-    /** @test */
-    public function it_does_not_send_a_message_when_from_missed(): void
+    public function test_it_does_not_send_a_message_when_from_missed(): void
     {
         $this->expectException(CouldNotSendNotification::class);
 


### PR DESCRIPTION
Support for `Laravel 10 & 11` was added.
The tests were updated to work on `PHPUnit 11` and the test configuration was migrated accordingly.